### PR TITLE
fix not working with deep file trees

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,4 +15,4 @@ function empty () {
 	return through.obj(function (file, enc, cb) {
         cb(null, file);
     });
-};
+}

--- a/index.js
+++ b/index.js
@@ -8,19 +8,11 @@
 
 "use strict";
 
-module.exports = function() {
-	var through = require("through"),
-		files = [];
+module.exports = empty;
 
-	return through(function(file) {
-		files.push(file);
-	}, function() {
-		var me = this;
-
-		files.forEach(function(file) {
-			me.push(file);
-		});
-
-		this.emit("end");
-	});
+function empty () {
+	var through = require("through2");
+	return through.obj(function (file, enc, cb) {
+        cb(null, file);
+    });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gulp-empty",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "Gulp task that does not do something",
 	"repository": {
 		"type": "git",
@@ -27,6 +27,6 @@
 		"no function"
 	],
 	"dependencies": {
-		"through": "^2.3.4"
+		"through2": "^0.6.5"
 	}
 }


### PR DESCRIPTION
For some reason, if I used the old implementation and I tried to use it on a deep file tree (a few levels), it only returned the files on the first level. Whereas, using:

``` js
function empty () {    
    return through.obj(function (file, enc, cb) {
        cb(null, file);
    });
}
```

it worked just fine.

Maybe it's the version of gulp that is causing this.
